### PR TITLE
Use Layout type instead of string for Dsn and Environment

### DIFF
--- a/NLog.Targets.Sentry.UnitTests/NLog.Targets.Sentry.UnitTests.csproj
+++ b/NLog.Targets.Sentry.UnitTests/NLog.Targets.Sentry.UnitTests.csproj
@@ -7,12 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="NLog" Version="4.5.2" />
-    <PackageReference Include="NLog.Config" Version="4.5.2" />
-    <PackageReference Include="NLog.Schema" Version="4.5.2" />
+    <PackageReference Include="NLog" Version="4.5.11" />
+    <PackageReference Include="NLog.Config" Version="4.5.11" />
+    <PackageReference Include="NLog.Schema" Version="4.5.11" />
     <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
   </ItemGroup>

--- a/NLog.Targets.Sentry.UnitTests/SentryTargetTests.cs
+++ b/NLog.Targets.Sentry.UnitTests/SentryTargetTests.cs
@@ -1,11 +1,11 @@
-﻿using Moq;
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Moq;
 using NLog.Config;
 using NUnit.Framework;
 using SharpRaven;
 using SharpRaven.Data;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
 
 namespace NLog.Targets.Sentry.UnitTests
 {
@@ -25,6 +25,22 @@ namespace NLog.Targets.Sentry.UnitTests
         }
 
         [Test]
+        public void TestInitialization()
+        {
+            var sentryTarget = new SentryTarget
+            {
+                Dsn = "http://25e27038b1df4930b93c96c170d95527:d87ac60bb07b4be8908845b23e914dae@test/4",
+                Environment = "Test",
+                Timeout = "00:00:10",
+            };
+
+            var logEventInfo = LogEventInfo.CreateNullEvent();
+            Assert.AreEqual("http://25e27038b1df4930b93c96c170d95527:d87ac60bb07b4be8908845b23e914dae@test/4", sentryTarget.Dsn.Render(logEventInfo));
+            Assert.AreEqual("Test", sentryTarget.Environment.Render(logEventInfo));
+            Assert.AreEqual("00:00:10", sentryTarget.Timeout);
+        }
+
+        [Test]
         public void TestPublicConstructor()
         {
             // ReSharper disable ObjectCreationAsStatement
@@ -38,14 +54,6 @@ namespace NLog.Targets.Sentry.UnitTests
                 configuration.LoggingRules.Add(new LoggingRule("*", LogLevel.Trace, sentryTarget));
                 LogManager.Configuration = configuration;
             });
-        }
-
-        [Test]
-        public void TestBadDsn()
-        {
-            // ReSharper disable ObjectCreationAsStatement
-            Assert.Throws<ArgumentException>(() => new SentryTarget(null) { Dsn = "http://localhost" });
-            // ReSharper restore ObjectCreationAsStatement
         }
 
         [Test]

--- a/NLog.Targets.Sentry/NLog.Targets.Sentry.csproj
+++ b/NLog.Targets.Sentry/NLog.Targets.Sentry.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="NLog" Version="4.5.2" />
+    <PackageReference Include="NLog" Version="4.5.11" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
1) Used Layout type instead of string for Dsn and Environment
2) Updated NLog to 4.5.11

You can use values from the App Settings configuration. [AppSetting Layout Renderer](https://github.com/NLog/NLog/wiki/AppSetting-Layout-Renderer) is required.
```
<target name="Sentry" type="Sentry"
        dsn="${appsetting:name=SentryDsn}"
        environment="${appsetting:name=SentryEnvironment}" />
```

You can use values from the appsettings.json or other configuration in .NET Core. [ConfigSetting Layout Renderer](https://github.com/NLog/NLog/wiki/ConfigSetting-Layout-Renderer) is required.

```
<target name="sentry" type="Sentry"
        dsn="${configsetting:name=SentryDsn}"
        environment="${configsetting:name=SentryEnvironment}" />
```
